### PR TITLE
add a dependency fetch step; update test case dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,11 @@
-FROM ballerina/ballerina:2201.2.3 AS build
-
-# Pull any ballerina package and download dependencies
-USER root
-WORKDIR /home/ballerina
-COPY tests/example-success/ .
-RUN bal build
-
-FROM ballerina/ballerina:2201.2.3 AS runner
+FROM ballerina/ballerina:2201.2.3
 
 # install packages required to run the tests
 USER root
 RUN apk add --no-cache jq coreutils
 
 # copy cached ballerina libraries
-COPY --from=build /root/.ballerina/repositories /root/.ballerina/repositories
+RUN bal pull ballerina/io:1.2.2
 
 WORKDIR /opt/test-runner
 


### PR DESCRIPTION
This might be the best solution. I discovered the ballerina container will copy any downloaded libraries to a `.ballerina` folder in the solution dir which can be moved in the run command.

this shows the image pulling the libs then building the container. I tested it on the hello-world exercise. 
![image](https://user-images.githubusercontent.com/3012311/202575456-ce7adbdc-6380-455b-9a24-9e5bbb98abda.png)
