### PR TITLE
update test flag to reduce testing time

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -31,9 +31,10 @@ for test_dir in tests/*; do
     diff "${results_file_path}" "${expected_results_file_path}"
 
     if [ $? -ne 0 ]; then
+        echo "${test_dir_name}: Result comparison failed!"
         exit_code=1
     else
-        echo "Test ${test_dir_name} successful!"
+        echo "${test_dir_name}: Result comparison successful!"
     fi
 done
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -44,9 +44,9 @@ fi
 if [ ! -e Dependencies.toml ]; then
     test_output="$test_output \n WARNING: student did not upload Dependencies.toml."
 fi
-# The `--code-coverage` flag generates a test_results.json file
+# The `--test-report` flag generates a test_results.json file
 # Capture err_msg from stderr output
-{ err_msg="$(bal test --code-coverage --offline 2>&1 1>&3 3>&-)"; } 3>&1;
+{ err_msg="$(bal test --test-report --offline 2>&1 1>&3 3>&-)"; } 3>&1;
 if [ $? -ne 0 ]; then
     test_output="$test_output \n Compile Failed: \n $err_msg"
 fi


### PR DESCRIPTION
This should help improve runtime by reducing the test coverage details. more discussion on [this thread](https://forum.exercism.org/t/ballerina-test-runner-timeouts/1614/7)